### PR TITLE
Added Database version control system

### DIFF
--- a/CS157AProject/WebContent/WEB-INF/web.xml
+++ b/CS157AProject/WebContent/WEB-INF/web.xml
@@ -17,5 +17,8 @@
   <filter-name>UserFilter</filter-name>
   <url-pattern>/dashboard/*</url-pattern>
 </filter-mapping>
+  <listener>
+    <listener-class>sjsu.cs157a.Application</listener-class>
+  </listener>
 
 </web-app>

--- a/CS157AProject/src/sjsu/cs157a/Application.java
+++ b/CS157AProject/src/sjsu/cs157a/Application.java
@@ -1,0 +1,61 @@
+package sjsu.cs157a;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.output.MigrateOutput;
+import org.flywaydb.core.api.output.MigrateResult;
+import sjsu.cs157a.config.DatabaseConnection;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class Application implements ServletContextListener {
+
+    //tasks to run when the application starts
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        System.out.println("Hi thje app just started");
+
+        try {
+            Properties dbProperties = initializeProperties();
+            String dbURL = dbProperties.getProperty("dbURL");
+            String dbName = dbProperties.getProperty("dbName");
+            String miscSetting = dbProperties.getProperty("miscSetting");
+            String dbUsername = dbProperties.getProperty("dbUsername");
+            String dbPassword = dbProperties.getProperty("dbPassword");
+
+            //do migrations with flyway
+            Flyway flyway = Flyway.configure()
+                    .dataSource(dbURL + dbName + miscSetting, dbUsername, dbPassword)
+                    .locations("sjsu/cs157a/migrations")
+                    .baselineOnMigrate(true)
+                    .load();
+
+            MigrateResult migrateResult = flyway.migrate();
+//
+            System.out.println("Migrations executed: " + migrateResult.migrationsExecuted);
+            for(MigrateOutput migration : migrateResult.migrations)
+                System.out.println(migration.filepath);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+
+    }
+
+    Properties initializeProperties() throws IOException {
+        Properties dbProperties = new Properties();
+        InputStream inputStream = DatabaseConnection.class.getClassLoader().getResourceAsStream("config.properties");
+
+        dbProperties.load(inputStream);
+
+        return dbProperties;
+    }
+}

--- a/CS157AProject/src/sjsu/cs157a/migrations/V2__Create_person_table.sql
+++ b/CS157AProject/src/sjsu/cs157a/migrations/V2__Create_person_table.sql
@@ -1,0 +1,3 @@
+# change the length of password to 100
+ALTER TABLE `project157a`.`user_register`
+    CHANGE COLUMN `password` `password` VARCHAR(100) NULL DEFAULT NULL ;

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,27 @@
             <version>8.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.servlet/jstl -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.servlet/servlet-api -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api -->
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>jsp-api</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,17 @@
             <version>8.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>7.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.21</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
Added application.java, which is the main starting point for the whole application, and [Flyway](https://flywaydb.org/documentation/), the database version control.

When trying to test it, remember to import the new libraries with Maven, and make sure it's in the WEB-inf output directory.

From now on, if there are any database schema changes to make, we put the SQL code in the /migrations folder. There is a [specific naming system](https://flywaydb.org/documentation/concepts/migrations#naming-1) to learn, for any subsequent changes to the database to be applied.